### PR TITLE
Initial WordPress Plugin Review | Fix basic issues

### DIFF
--- a/.github/workflows/release-pipeline-zip.yml
+++ b/.github/workflows/release-pipeline-zip.yml
@@ -29,7 +29,11 @@ jobs:
       run: npm install
 
     - name: Build Javascript
-      run: npm run build  
+      run: npm run build
+    
+    - name: Manipulations for WordPress Plugin Release
+    # 1. Replace generated echos by escaped output
+      run: sed -i 's/echo \$err;/echo esc_html(\$err);/' vendor/autoload.php
       
     - name: Archive Pipeline Build
       uses: thedoctor0/zip-release@0.7.5

--- a/.github/workflows/release-pipeline-zip.yml
+++ b/.github/workflows/release-pipeline-zip.yml
@@ -35,6 +35,9 @@ jobs:
     # 1. Replace generated echos by escaped output
       run: sed -i 's/echo \$err;/echo esc_html(\$err);/' lib/autoload.php
       
+    - name: Prepare release folder
+      run: mkdir releases/
+
     - name: Archive Pipeline Build
       uses: thedoctor0/zip-release@0.7.5
       with:

--- a/.github/workflows/release-pipeline-zip.yml
+++ b/.github/workflows/release-pipeline-zip.yml
@@ -33,7 +33,7 @@ jobs:
     
     - name: Manipulations for WordPress Plugin Release
     # 1. Replace generated echos by escaped output
-      run: sed -i 's/echo \$err;/echo esc_html(\$err);/' vendor/autoload.php
+      run: sed -i 's/echo \$err;/echo esc_html(\$err);/' lib/autoload.php
       
     - name: Archive Pipeline Build
       uses: thedoctor0/zip-release@0.7.5

--- a/.github/workflows/release-pipeline-zip.yml
+++ b/.github/workflows/release-pipeline-zip.yml
@@ -39,11 +39,11 @@ jobs:
       uses: thedoctor0/zip-release@0.7.5
       with:
         type: 'zip'
-        filename: release-${{ github.run_id }}.zip
+        filename: releases/snapshot-${{ github.run_id }}.zip
         exclusions: '*.git* /*node_modules/* .editorconfig phpunit.xml.dist composer.json composer.lock .wp-env.json /src/* /tests/* package.json package-lock.json /assets/*'
     
     - name: Upload Pipeline Release
       uses: actions/upload-artifact@v4
       with:
         name: Release ${{ github.run_id }} (SAMS Plugin)
-        path: release-${{ github.run_id }}.zip
+        path: releases/snapshot-${{ github.run_id }}.zip

--- a/sams-integration.php
+++ b/sams-integration.php
@@ -16,6 +16,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
 if ( file_exists( __DIR__ . '/lib/autoload.php' ) ) {
 
     require_once __DIR__ . '/lib/autoload.php';
@@ -28,8 +29,8 @@ if ( file_exists( __DIR__ . '/lib/autoload.php' ) ) {
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
-function create_block_wp_sams_plugin_block_init() {
+function samsintegration_initialize_blocktypes() {
 	register_block_type( __DIR__ . '/build/blocks/sams-ranking' );
 	register_block_type( __DIR__ . '/build/blocks/sams-fixtures' );
 }
-add_action( 'init', 'create_block_wp_sams_plugin_block_init' );
+add_action( 'init', 'samsintegration_initialize_blocktypes' );

--- a/src/blocks/sams-fixtures/render.php
+++ b/src/blocks/sams-fixtures/render.php
@@ -31,15 +31,15 @@ if (isset($attributes)
 
 	<tr>
     <td class="date">
-		<?php echo $fixture->date; ?>
+		<?php esc_html_e($fixture->date); ?>
         <br>
-		<?php echo $fixture->startTime; ?> Uhr
+		<?php esc_html_e($fixture->startTime); ?> Uhr
     </td>
     <td class="fixture">
-		<span class="fixture-name"> <?php echo $fixture->teamHome . " - " . $fixture->teamAway ?></span>
-		<span class="fixture-result"><?php if ($fixture->hasResult()) { echo " (" . $fixture->score . ")"; }; ?></span>
+		<span class="fixture-name"> <?php esc_html_e($fixture->teamHome . " - " . $fixture->teamAway); ?></span>
+		<span class="fixture-result"><?php if ($fixture->hasResult()) { esc_html_e(" (" . $fixture->score . ")"); }; ?></span>
 	</td>
-    <td class="venue"><?php echo $fixture->venue; ?></td>
+    <td class="venue"><?php esc_html_e($fixture->venue); ?></td>
 </tr>
 
 <?php };?>

--- a/src/blocks/sams-ranking/render.php
+++ b/src/blocks/sams-ranking/render.php
@@ -26,12 +26,12 @@ if (isset($attributes)
 	<?php foreach ($ranking->rankingEntries as $entry) { ?>
 
 	<tr>
-		<td class="rank"><?php echo $entry->place; ?></td>
-		<td class="teamName"><?php echo $entry->teamName; ?></td>
-		<td class="games"><?php echo $entry->games; ?></td>
-		<td class="balls"><?php echo $entry->ballsPro . ':' . $entry->ballsCon; ?></td>
-		<td class="sets"><?php echo $entry->setsPro . ':' . $entry->setsCon; ?></td>
-		<td class="points"><?php echo $entry->points; ?></td>
+		<td class="rank"><?php esc_html_e($entry->place); ?></td>
+		<td class="teamName"><?php esc_html_e($entry->teamName); ?></td>
+		<td class="games"><?php esc_html_e($entry->games); ?></td>
+		<td class="balls"><?php esc_html_e($entry->ballsPro . ':' . $entry->ballsCon); ?></td>
+		<td class="sets"><?php esc_html_e($entry->setsPro . ':' . $entry->setsCon); ?></td>
+		<td class="points"><?php esc_html_e($entry->points); ?></td>
 	</tr>
 
 	<?php };?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-echo "Bootstraped!";
 
 if ( file_exists( __DIR__ . '/../lib/autoload.php' ) ) {
     require_once __DIR__ . '/../lib/autoload.php'; // Pfad zur Composer-Autoload-Datei


### PR DESCRIPTION
# Fixes from the reviewers Mail

## Variables and options must be escaped when echo'd

Much related to sanitizing everything, all variables that are echoed need to be escaped when they're echoed, so it can't hijack users or (worse) admin screens. There are many esc_*() functions you can use to make sure you don't show people the wrong data, as well as some that will allow you to echo HTML safely. 

At this time, we ask you escape all $-variables, options, and any sort of generated data when it is being echoed. That means you should not be escaping when you build a variable, but when you output it at the end. We call this 'escaping late.' 

Besides protecting yourself from a possible XSS vulnerability, escaping late makes sure that you're keeping the future you safe. While today your code may be only outputted hardcoded content, that may not be true in the future. By taking the time to properly escape when you echo, you prevent a mistake in the future from becoming a critical security issue. 

This remains true of options you've saved to the database. Even if you've properly sanitized when you saved, the tools for sanitizing and escaping aren't interchangeable. Sanitizing makes sure it's safe for processing and storing in the database. Escaping makes it safe to output. 

Also keep in mind that sometimes a function is echoing when it should really be returning content instead. This is a common mistake when it comes to returning JSON encoded content. Very rarely is that actually something you should be echoing at all. Echoing is because it needs to be on the screen, read by a human. Returning (which is what you would do with an API) can be json encoded, though remember to sanitize when you save to that json object! 

There are a number of options to secure all types of content (html, email, etc). Yes, even HTML needs to be properly escaped. 

https://developer.wordpress.org/apis/security/escaping/

Remember: You must use the most appropriate functions for the context. There is pretty much an option for everything you could echo. Even echoing HTML safely. 

Example(s) from your plugin: 
build/blocks/sams-fixtures/render.php:40 <span class="fixture-result"><?php if ($fixture->hasResult()) { echo " (" . $fixture->score . ")"; }; ?></span>
 -----> echo " (" . $fixture->score . ")";
build/blocks/sams-ranking/render.php:32 <td class="balls"><?php echo $entry->ballsPro . ':' . $entry->ballsCon; ?></td>
build/blocks/sams-ranking/render.php:29 <td class="rank"><?php echo $entry->place; ?></td>
build/blocks/sams-ranking/render.php:34 <td class="points"><?php echo $entry->points; ?></td>
build/blocks/sams-fixtures/render.php:34 <?php echo $fixture->date; ?>
lib/autoload.php:14 echo $err;
# ↳ Detected origin: 'Composer 2.3.0 dropped support for autoloading on PHP <5.6 and you are running ' . PHP_VERSION . ', please upgrade PHP or use Composer 2.2 LTS via "composer self-update --2.2". Aborting.' . PHP_EOL
# ↳ Remember to ALWAYS escape as LATE as possible as with a PROPER function for the context.
build/blocks/sams-fixtures/render.php:42 <td class="venue"><?php echo $fixture->venue; ?></td>
build/blocks/sams-ranking/render.php:31 <td class="games"><?php echo $entry->games; ?></td>

... out of a total of 12 incidences.

## Generic function/class/define/namespace/option names

All plugins must have unique function names, namespaces, defines, class and option names. This prevents your plugin from conflicting with other plugins or themes. We need you to update your plugin to use more unique and distinct names. 

A good way to do this is with a prefix. For example, if your plugin is called "Easy Custom Post Types" then you could use names like these: 
•	function ecpt_save_post()
•	class ECPT_Admin{}
•	namespace ECPT;
•	update_option( 'ecpt_settings', $settings );
•	define( 'ECPT_LICENSE', true );
•	global $ecpt_options;

Don't try to use two (2) or three (3) letter prefixes anymore. We host nearly 100-thousand plugins on WordPress.org alone. There are tens of thousands more outside our servers. Believe us, you’re going to run into conflicts. 

You also need to avoid the use of __ (double underscores), wp_ , or _ (single underscore) as a prefix. Those are reserved for WordPress itself. You can use them inside your classes, but not as stand-alone function. 

Please remember, if you're using _n() or __() for translation, that's fine. We're only talking about functions you've created for your plugin, not the core functions from WordPress. In fact, those core features are why you need to not use those prefixes in your own plugin! You don't want to break WordPress for your users. 

Related to this, using if (!function_exists('NAME')) { around all your functions and classes sounds like a great idea until you realize the fatal flaw. If something else has a function with the same name and their code loads first, your plugin will break. Using if-exists should be reserved for shared libraries only. 

Remember: Good prefix names are unique and distinct to your plugin. This will help you and the next person in debugging, as well as prevent conflicts. 

Analysis result: 
# This plugin is using the prefix "samsplugin" for 4 element(s).
# This plugin is using the prefix "composer" for 2 element(s).

# Cannot use "create" as a prefix.
sams-integration.php:31 function create_block_wp_sams_plugin_block_init


## Allowing Direct File Access to plugin files

Direct file access is when someone directly queries your file. This can be done by simply entering the complete path to the file in the URL bar of the browser but can also be done by doing a POST request directly to the file. For files that only contain a PHP class the risk of something funky happening when directly accessed is pretty small. For files that contain procedural code, functions and function calls, the chance of security risks is a lot bigger. 

You can avoid this by putting this code at the top of all PHP files that could potentially execute code if accessed directly : 
    if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly

Example(s) from your plugin: 
lib/autoload.php:5 
build/blocks/sams-fixtures/render.php:9 
lib/composer/installed.php:1 
lib/composer/autoload_psr4.php:5 
lib/composer/autoload_classmap.php:5 
build/blocks/sams-ranking/render.php:8 
lib/composer/autoload_namespaces.php:5 
